### PR TITLE
Uninstall docs expanded with a new Cleanup subsection: after running the uninstall script, follow explicit steps to remove the cloned project folder so no residual files remain. This clarifies post-uninstall cleanup for users.

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ bash uninstall.sh --prune
 After uninstalling, remove the cloned folder:
 
 ```bash
-cd ..
+cd 
 rm -f -r "termux-ngrok"
 ```
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,8 @@ bash uninstall.sh --prune
 After uninstalling, remove the cloned folder:
 
 ```bash
-rm -f -r "termux-ngrok"
+cd ..
+rm -r "termux-ngrok"
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -54,14 +54,6 @@ To uninstall and automatically clean the package cache without being prompted:
 bash uninstall.sh --prune
 ```
 
-### Cleanup
-
-After uninstalling, remove the cloned folder:
-
-```bash
-rm -f -r "termux-ngrok"
-```
-
 ---
 
 ## 📜 License

--- a/README.md
+++ b/README.md
@@ -54,6 +54,14 @@ To uninstall and automatically clean the package cache without being prompted:
 bash uninstall.sh --prune
 ```
 
+### Cleanup
+
+After uninstalling, remove the cloned folder:
+
+```bash
+rm -f -r "termux-ngrok"
+```
+
 ---
 
 ## 📜 License

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ After uninstalling, remove the cloned folder:
 
 ```bash
 cd ..
-rm -r "termux-ngrok"
+rm -f -r "termux-ngrok"
 ```
 
 ---


### PR DESCRIPTION
Adds a "Cleanup" subsection to README's Uninstall section that documents changing to the parent directory and removing the cloned termux-ngrok folder with rm -r "termux-ngrok" after running bash uninstall.sh.